### PR TITLE
Remove libgcc-ng and libstdcxx-ng pins

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,14 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - bazel {{ bazel }}
+    # Use pins to control cos6/cos7 match
+    - libgcc-ng  {{ libgcc }}                      # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}                # [x86_64 and c_compiler_version == "7.2.*"]
   host:
     - python {{ python }}
+    # Use pins to control cos6/cos7 match
+    - libgcc-ng  {{ libgcc }}                      # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}                # [x86_64 and c_compiler_version == "7.2.*"]
   run:
     - python {{ python }}
     - six {{ six }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,21 +12,15 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - bazel {{ bazel }}
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
   host:
     - python {{ python }}
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
   run:
     - python {{ python }}
     - six {{ six }}


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Use of new compilers will get rid of libgcc-ng and libstdcxx-ng pins.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
